### PR TITLE
EGI 256ch electrodes support.

### DIFF
--- a/elecPreproc.m
+++ b/elecPreproc.m
@@ -19,6 +19,9 @@ switch lower(para(1).capType)
     case 'biosemi'
         load('./capBioSemiFullWithExtra.mat','capInfo');
         elecPool_P = capInfo{1};
+    case 'egi'
+        load('./capEGIFullWithExtra.mat','capInfo');
+        elecPool_P = capInfo{1};        
 end
 
 elecPool_N = {'nk1';'nk2';'nk3';'nk4'};

--- a/electrodePlacement.m
+++ b/electrodePlacement.m
@@ -67,11 +67,15 @@ if ~isempty(indP)
    if strcmpi(elecPara(1).capType,'biosemi')
        isBiosemi = 1;
        load('./capBioSemiFullWithExtra.mat','capInfo');
+   elseif strcmpi(elecPara(1).capType,'egi')
+       isEGI = 1;
+       isBiosemi = 0;
+       load('./capEGIFullWithExtra.mat','capInfo');
    else
        isBiosemi = 0;
        load('./cap1005FullWithExtra.mat','capInfo');
    end
-   [electrode_coord_P,center_P]= fitCap2individual(scalp,scalp_surface,landmarks,P2,capInfo,indP,isBiosemi);
+   [electrode_coord_P,center_P]= fitCap2individual(scalp,scalp_surface,landmarks,P2,capInfo,indP,isBiosemi,isEGI);
 else
     electrode_coord_P = []; center_P = [];
 end

--- a/fitCap2individual.m
+++ b/fitCap2individual.m
@@ -1,4 +1,4 @@
-function [electrode_coord,center]= fitCap2individual(scalp,scalp_surface,landmarks,P2,capInfo,indNeed,isBiosemi)
+function [electrode_coord,center]= fitCap2individual(scalp,scalp_surface,landmarks,P2,capInfo,indNeed,isBiosemi,isEGI)
 % [electrode_coord,center]= fitCap2individual(scalp,scalp_surface,landmarks,P2,capInfo,indNeed,isBiosemi)
 %
 % Place the electrodes with pre-defined coordinates in the standard EEG
@@ -70,8 +70,11 @@ distance_all = sum(sqrt(diff(yi).^2+diff(zi).^2));
 
 disp('wearing the cap...')
 elec = capInfo{1};
-if ~isBiosemi
+if ~(isBiosemi || isEGI)
     centralElec = {'Oz';'POz';'Pz';'CPz';'Cz';'FCz';'Fz';'AFz';'Fpz'};
+elseif isEGI==1
+    %centralElec = {'E126';'E119';'E101';'E81';'Cz';'E15';'E21';'E20';'E26'};
+    centralElec = {'E126';'E119';'E101';'E81';'E257';'E15';'E21';'AFz';'E26'};
 else
     centralElec = {'A19';'POz';'A6';'CPz';'A1';'FCz';'E17';'AFz';'E12'};
 end


### PR DESCRIPTION
  % modified command for using EGI montage.

roast('/Volumes/Mirror_HD/tACS_Modeling/PYE_EGI_test2/PYE.nii',{'E26',0.25,'E21',0.25,'E257',0.25,'E101',0.25,'E126',-1},'captype','egi','electype','ring')

% EGI electrodes are E1 to E256, referencing Hydrocel eeg cap.